### PR TITLE
Update cargo package manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,10 @@
 name = "rust-criu"
 version = "0.1.0"
 edition = "2021"
+description = "Rust bindings for CRIU"
+repository = "https://github.com/checkpoint-restore/rust-criu"
+readme = "README.md"
+license-file = "LICENSE"
 
 [dependencies]
 libc = "0.2"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# rust-criu
+
+`rust-criu` provides an interface to use [CRIU](https://criu.org/) in the
+same way as [go-criu](https://github.com/checkpoint-restore/go-criu) does.

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,0 @@
-rust-criu
-=========
-
-`rust-criu` provides an interface to use `CRIU <https://criu.org/>`_ in the
-same way as `go-criu <https://github.com/checkpoint-restore/go-criu>`_ does.


### PR DESCRIPTION
I added some minimal metadata to the manifest and published the package [here](https://crates.io/crates/rust-criu). I'm happy to transfer ownership to @adrianreber and/or anyone else, at which point you can [remove me](https://doc.rust-lang.org/cargo/commands/cargo-owner.html) as an owner. The registry authenticates using GitHub OAuth, so you don't have to manage a separate account.
I kept the changes as minimal as possible, but FWIW:
- It doesn't seem to like the rst format for the README, could convert to md
- Apparently it doesn't recognize the license file as being MIT and lists it as "non-standard", could just set `license = "MIT"`, [manifest docs](https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields)
Ref: https://github.com/checkpoint-restore/rust-criu/issues/2