### PR TITLE
readme: Add crates.io badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![crates.io](https://img.shields.io/crates/v/rust-criu.svg)](https://crates.io/crates/rust-criu)
+[![ci](https://github.com/checkpoint-restore/rust-criu/actions/workflows/test.yml/badge.svg)](https://github.com/checkpoint-restore/rust-criu/actions)
+
 # rust-criu
 
 `rust-criu` provides an interface to use [CRIU](https://criu.org/) in the


### PR DESCRIPTION
This pull request adds crates.io and CI badges to the README file.