### PR TITLE
pin protobuf dependency version to 3.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ license-file = "LICENSE"
 [dependencies]
 libc = "0.2"
 anyhow = "1.0.56"
-protobuf = "3.2.0"
+protobuf = "= 3.2.0"
 
 [build-dependencies]
-protobuf-codegen = "3.2.0"
+protobuf-codegen = "= 3.2.0"
 
 [lib]
 name = "rust_criu"


### PR DESCRIPTION
fixes #19

Currently I have left the check [rust_criu_protobuf/rpc.rs:26](https://github.com/checkpoint-restore/rust-criu/blob/main/src/rust_criu_protobuf/rpc.rs#L24-L26) , but can remove if you want. Also pinned codegen dependency to the same version.