### PR TITLE
Add lazy_pages and page_server support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,6 +129,18 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "once_cell"
@@ -239,6 +257,7 @@ name = "rust-criu"
 version = "0.5.0"
 dependencies = [
  "libc",
+ "nix",
  "protobuf",
  "protobuf-codegen",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,6 +129,18 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "once_cell"
@@ -239,6 +257,7 @@ name = "rust-criu"
 version = "0.5.0"
 dependencies = [
  "libc",
+ "nix",
  "protobuf",
  "protobuf-codegen",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,13 @@ license-file = "LICENSE"
 libc = "0.2"
 thiserror = "1"
 protobuf = "= 3.7.2"
-nix = "0.31.2"
+nix = { version = "0.31", features = ["fs", "signal", "process"] }
 
 [build-dependencies]
 protobuf-codegen = "= 3.7.2"
+
+[dev-dependencies]
+nix = { version = "0.31", features = ["fs", "signal", "process"] }
 
 [lib]
 name = "rust_criu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license-file = "LICENSE"
 libc = "0.2"
 thiserror = "1"
 protobuf = "= 3.7.2"
+nix = "0.31.2"
 
 [build-dependencies]
 protobuf-codegen = "= 3.7.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license-file = "LICENSE"
 libc = "0.2"
 thiserror = "2"
 protobuf = "= 3.7.2"
+nix = "0.31.2"
 
 [build-dependencies]
 protobuf-codegen = "= 3.7.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,13 @@ license-file = "LICENSE"
 libc = "0.2"
 thiserror = "2"
 protobuf = "= 3.7.2"
-nix = "0.31.2"
+nix = { version = "0.31", features = ["fs", "signal", "process"] }
 
 [build-dependencies]
 protobuf-codegen = "= 3.7.2"
+
+[dev-dependencies]
+nix = { version = "0.31", features = ["fs", "signal", "process"] }
 
 [lib]
 name = "rust_criu"

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 use tests::action_script::action_script_test;
 use tests::basic::basic_test;
 use tests::external_netns::external_netns_test;
+use tests::lazy_pages::lazy_pages_test;
 use tests::orphan_pts::orphan_pts_master_test;
 use tests::version::version_test;
 
@@ -29,4 +30,5 @@ fn main() {
     action_script_test(&criu_bin_path);
     external_netns_test(&criu_bin_path);
     orphan_pts_master_test(&criu_bin_path);
+    lazy_pages_test(&criu_bin_path);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod rust_criu_protobuf;
 
-use protobuf::Message;
+use protobuf::{Message, MessageField};
 use rust_criu_protobuf::rpc;
 use rust_criu_protobuf::rpc::Criu_notify;
 use std::fs::File;
@@ -207,7 +207,7 @@ impl Criu {
         req.set_type(request_type);
 
         if let Some(co) = criu_opts {
-            req.opts = protobuf::MessageField::some(co);
+            req.opts = MessageField::some(co);
         }
 
         let fd = self.sv[0];
@@ -686,7 +686,7 @@ impl Criu {
             let mut ps = rpc::Criu_page_server_info::new();
             ps.set_address(address.clone());
             ps.set_port(port);
-            criu_opts.ps = protobuf::MessageField::some(ps);
+            criu_opts.ps = MessageField::some(ps);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,8 @@ pub struct Criu {
     auto_dedup: Option<bool>,
     parent_img: Option<String>,
     status_fd: Option<i32>,
+    lazy_pages: Option<bool>,
+    page_server: Option<(String, i32)>,
 }
 
 impl Criu {
@@ -145,6 +147,8 @@ impl Criu {
             auto_dedup: None,
             parent_img: None,
             status_fd: None,
+            lazy_pages: None,
+            page_server: None,
         })
     }
 
@@ -535,6 +539,14 @@ impl Criu {
         self.status_fd = Some(status_fd);
     }
 
+    pub fn set_lazy_pages(&mut self, lazy_pages: bool) {
+        self.lazy_pages = Some(lazy_pages);
+    }
+
+    pub fn set_page_server(&mut self, address: String, port: i32) {
+        self.page_server = Some((address, port));
+    }
+
     fn fill_criu_opts(&mut self, criu_opts: &mut rpc::Criu_opts) {
         if self.pid != -1 {
             criu_opts.set_pid(self.pid);
@@ -665,6 +677,17 @@ impl Criu {
         if let Some(status_fd) = self.status_fd {
             criu_opts.set_status_fd(status_fd);
         }
+
+        if let Some(lazy_pages) = self.lazy_pages {
+            criu_opts.set_lazy_pages(lazy_pages);
+        }
+
+        if let Some((ref address, port)) = self.page_server {
+            let mut ps = rpc::Criu_page_server_info::new();
+            ps.set_address(address.clone());
+            ps.set_port(port);
+            criu_opts.ps = protobuf::MessageField::some(ps);
+        }
     }
 
     fn clear(&mut self) {
@@ -695,6 +718,8 @@ impl Criu {
         self.auto_dedup = None;
         self.parent_img = None;
         self.status_fd = None;
+        self.lazy_pages = None;
+        self.page_server = None;
     }
 
     /// Dump (checkpoint) a process.
@@ -888,5 +913,45 @@ mod tests {
         let mut opts = rpc::Criu_opts::default();
         criu.fill_criu_opts(&mut opts);
         assert!(!opts.has_status_fd());
+    }
+
+    #[test]
+    fn set_lazy_pages_fills_criu_opts() {
+        let mut criu = Criu::new().unwrap();
+        criu.set_lazy_pages(true);
+
+        let mut opts = rpc::Criu_opts::default();
+        criu.fill_criu_opts(&mut opts);
+        assert!(opts.lazy_pages());
+    }
+
+    #[test]
+    fn lazy_pages_default_not_set() {
+        let mut criu = Criu::new().unwrap();
+
+        let mut opts = rpc::Criu_opts::default();
+        criu.fill_criu_opts(&mut opts);
+        assert!(!opts.has_lazy_pages());
+    }
+
+    #[test]
+    fn set_page_server_fills_criu_opts() {
+        let mut criu = Criu::new().unwrap();
+        criu.set_page_server(String::from("127.0.0.1"), 1234);
+
+        let mut opts = rpc::Criu_opts::default();
+        criu.fill_criu_opts(&mut opts);
+        assert!(opts.ps.is_some());
+        assert_eq!(opts.ps.address(), "127.0.0.1");
+        assert_eq!(opts.ps.port(), 1234);
+    }
+
+    #[test]
+    fn page_server_default_not_set() {
+        let mut criu = Criu::new().unwrap();
+
+        let mut opts = rpc::Criu_opts::default();
+        criu.fill_criu_opts(&mut opts);
+        assert!(opts.ps.is_none());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod rust_criu_protobuf;
 
-use protobuf::Message;
+use protobuf::{Message, MessageField};
 use rust_criu_protobuf::rpc;
 use rust_criu_protobuf::rpc::Criu_notify;
 use std::fs::File;
@@ -207,7 +207,7 @@ impl Criu {
         req.set_type(request_type);
 
         if let Some(co) = criu_opts {
-            req.opts = protobuf::MessageField::some(co);
+            req.opts = MessageField::some(co);
         }
 
         let fd = self.sv[0];
@@ -679,7 +679,7 @@ impl Criu {
             let mut ps = rpc::Criu_page_server_info::new();
             ps.set_address(address.clone());
             ps.set_port(port);
-            criu_opts.ps = protobuf::MessageField::some(ps);
+            criu_opts.ps = MessageField::some(ps);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,8 @@ pub struct Criu {
     auto_dedup: Option<bool>,
     parent_img: Option<String>,
     status_fd: Option<i32>,
+    lazy_pages: Option<bool>,
+    page_server: Option<(String, i32)>,
 }
 
 impl Criu {
@@ -145,6 +147,8 @@ impl Criu {
             auto_dedup: None,
             parent_img: None,
             status_fd: None,
+            lazy_pages: None,
+            page_server: None,
         })
     }
 
@@ -528,6 +532,14 @@ impl Criu {
         self.status_fd = Some(status_fd);
     }
 
+    pub fn set_lazy_pages(&mut self, lazy_pages: bool) {
+        self.lazy_pages = Some(lazy_pages);
+    }
+
+    pub fn set_page_server(&mut self, address: String, port: i32) {
+        self.page_server = Some((address, port));
+    }
+
     fn fill_criu_opts(&mut self, criu_opts: &mut rpc::Criu_opts) {
         if let Some(pid) = self.pid {
             criu_opts.set_pid(pid);
@@ -658,6 +670,17 @@ impl Criu {
         if let Some(status_fd) = self.status_fd {
             criu_opts.set_status_fd(status_fd);
         }
+
+        if let Some(lazy_pages) = self.lazy_pages {
+            criu_opts.set_lazy_pages(lazy_pages);
+        }
+
+        if let Some((ref address, port)) = self.page_server {
+            let mut ps = rpc::Criu_page_server_info::new();
+            ps.set_address(address.clone());
+            ps.set_port(port);
+            criu_opts.ps = protobuf::MessageField::some(ps);
+        }
     }
 
     fn clear(&mut self) {
@@ -688,6 +711,8 @@ impl Criu {
         self.auto_dedup = None;
         self.parent_img = None;
         self.status_fd = None;
+        self.lazy_pages = None;
+        self.page_server = None;
     }
 
     /// Dump (checkpoint) a process.
@@ -878,5 +903,45 @@ mod tests {
         let mut opts = rpc::Criu_opts::default();
         criu.fill_criu_opts(&mut opts);
         assert!(!opts.has_status_fd());
+    }
+
+    #[test]
+    fn set_lazy_pages_fills_criu_opts() {
+        let mut criu = Criu::new().unwrap();
+        criu.set_lazy_pages(true);
+
+        let mut opts = rpc::Criu_opts::default();
+        criu.fill_criu_opts(&mut opts);
+        assert!(opts.lazy_pages());
+    }
+
+    #[test]
+    fn lazy_pages_default_not_set() {
+        let mut criu = Criu::new().unwrap();
+
+        let mut opts = rpc::Criu_opts::default();
+        criu.fill_criu_opts(&mut opts);
+        assert!(!opts.has_lazy_pages());
+    }
+
+    #[test]
+    fn set_page_server_fills_criu_opts() {
+        let mut criu = Criu::new().unwrap();
+        criu.set_page_server(String::from("127.0.0.1"), 1234);
+
+        let mut opts = rpc::Criu_opts::default();
+        criu.fill_criu_opts(&mut opts);
+        assert!(opts.ps.is_some());
+        assert_eq!(opts.ps.address(), "127.0.0.1");
+        assert_eq!(opts.ps.port(), 1234);
+    }
+
+    #[test]
+    fn page_server_default_not_set() {
+        let mut criu = Criu::new().unwrap();
+
+        let mut opts = rpc::Criu_opts::default();
+        criu.fill_criu_opts(&mut opts);
+        assert!(opts.ps.is_none());
     }
 }

--- a/src/tests/lazy_pages.rs
+++ b/src/tests/lazy_pages.rs
@@ -1,4 +1,10 @@
-use std::os::unix::io::{AsRawFd, OwnedFd, RawFd};
+use nix::errno::Errno;
+use nix::fcntl::{fcntl, FcntlArg, FdFlag};
+use nix::sys::signal::{kill, Signal};
+use nix::sys::wait::waitpid;
+use nix::unistd::Pid;
+use std::os::fd::{AsFd, BorrowedFd};
+use std::os::unix::io::{AsRawFd, OwnedFd};
 use std::process::Command;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -7,17 +13,14 @@ const IMAGES_DIR: &str = "test/images";
 const READY_TIMEOUT: Duration = Duration::from_secs(5);
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
 
-// Create a pipe and make the read end non-blocking
 fn create_state_pipe() -> std::io::Result<(OwnedFd, OwnedFd)> {
     let (r, w) = nix::unistd::pipe().map_err(|e| std::io::Error::from_raw_os_error(e as i32))?;
-    let fd = r.as_raw_fd();
-    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
-    if flags < 0 {
-        return Err(std::io::Error::last_os_error());
-    }
-    if unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0 {
-        return Err(std::io::Error::last_os_error());
-    }
+    let flags = FdFlag::from_bits_truncate(
+        fcntl(w.as_fd(), FcntlArg::F_GETFD)
+            .map_err(|e| std::io::Error::from_raw_os_error(e as i32))?,
+    );
+    fcntl(w.as_fd(), FcntlArg::F_SETFD(flags & !FdFlag::FD_CLOEXEC))
+        .map_err(|e| std::io::Error::from_raw_os_error(e as i32))?;
     Ok((r, w))
 }
 
@@ -35,7 +38,7 @@ pub fn lazy_pages_test(criu_bin_path: &str) {
 
     if let Err(e) = std::fs::create_dir(IMAGES_DIR) {
         if e.kind() != std::io::ErrorKind::AlreadyExists {
-            unsafe { libc::kill(pid, libc::SIGKILL) };
+            let _ = kill(Pid::from_raw(pid), Signal::SIGKILL);
             panic!(
                 "Creating image directory '{}' failed with {:#?}",
                 IMAGES_DIR, e
@@ -51,40 +54,37 @@ pub fn lazy_pages_test(criu_bin_path: &str) {
     let (pipe_r, pipe_w) = match create_state_pipe() {
         Ok(p) => p,
         Err(e) => {
-            unsafe { libc::kill(pid, libc::SIGKILL) };
+            let _ = kill(Pid::from_raw(pid), Signal::SIGKILL);
             panic!("Creating pipe failed: {:#?}", e);
         }
     };
-    let pipe_r_fd = pipe_r.as_raw_fd();
-    let pipe_w_fd = pipe_w.as_raw_fd();
 
     // Dynamically choose a free ephemeral port so a leaked page-server
     // from an earlier run does not hang this test with EADDRINUSE.
     let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
     let port = listener.local_addr().unwrap().port() as i32;
     drop(listener);
+    let status_fd = pipe_w.as_raw_fd();
 
-    // Run dump on a background thread: with --lazy-pages, dump() returns only
-    // after restore has fetched all pages through the daemon.
     let criu_bin_for_dump = criu_bin_path.to_string();
     let dump_handle = thread::spawn(move || -> Result<(), String> {
+        // Keep pipe_w alive until criu.dump() spawns CRIU swrk so the writer fd is inherited.
+        let _pipe_w = pipe_w;
         let mut criu = rust_criu::Criu::new_with_criu_path(criu_bin_for_dump)
             .map_err(|e| format!("Criu::new failed: {:#?}", e))?;
         criu.set_pid(pid);
         criu.set_images_dir_fd(images_dir_fd);
         criu.set_lazy_pages(true);
         criu.set_page_server("0.0.0.0".to_string(), port);
-        criu.set_status_fd(pipe_w_fd);
+        criu.set_status_fd(status_fd);
         criu.dump().map_err(|e| format!("{:#?}", e))
     });
 
-    // Wait until CRIU reports readiness before starting the daemon.
-    let ready = wait_for_ready(pipe_r_fd, READY_TIMEOUT);
-    drop(pipe_w);
+    let ready = wait_for_ready(pipe_r.as_fd(), READY_TIMEOUT);
     drop(pipe_r);
 
     if !ready {
-        unsafe { libc::kill(pid, libc::SIGKILL) };
+        let _ = kill(Pid::from_raw(pid), Signal::SIGKILL);
         let _ = dump_handle.join();
         panic!(
             "CRIU lazy-pages page-server did not become ready within {:?}",
@@ -92,29 +92,29 @@ pub fn lazy_pages_test(criu_bin_path: &str) {
         );
     }
 
+    // CRIU writes inventory.img once the dump-side state is established;
+    // its absence here means the page-server signalled readiness without
+    // producing a usable image set, so there is nothing for the daemon to serve.
+    if !std::path::Path::new(IMAGES_DIR)
+        .join("inventory.img")
+        .exists()
+    {
+        let _ = kill(Pid::from_raw(pid), Signal::SIGKILL);
+        let _ = dump_handle.join();
+        panic!("inventory.img was not written to {}", IMAGES_DIR);
+    }
+
     // Launch the lazy-pages daemon and wait via --status-fd until it is listening
     // on lazy-pages.socket
     let (daemon_pipe_r, daemon_pipe_w) = match create_state_pipe() {
         Ok(p) => p,
         Err(e) => {
-            unsafe { libc::kill(pid, libc::SIGKILL) };
+            let _ = kill(Pid::from_raw(pid), Signal::SIGKILL);
             let _ = dump_handle.join();
             panic!("Creating daemon status pipe failed: {:#?}", e);
         }
     };
-    let daemon_pipe_r_fd = daemon_pipe_r.as_raw_fd();
     let daemon_pipe_w_fd = daemon_pipe_w.as_raw_fd();
-
-    // nix::unistd::pipe() sets O_CLOEXEC, so the write end must be made
-    // inheritable before spawning the daemon.
-    if unsafe { libc::fcntl(daemon_pipe_w_fd, libc::F_SETFD, 0) } < 0 {
-        unsafe { libc::kill(pid, libc::SIGKILL) };
-        let _ = dump_handle.join();
-        panic!(
-            "Clearing FD_CLOEXEC on daemon pipe failed: {}",
-            std::io::Error::last_os_error()
-        );
-    }
 
     println!("Spawning lazy-pages daemon");
     let port_str = port.to_string();
@@ -136,23 +136,20 @@ pub fn lazy_pages_test(criu_bin_path: &str) {
     {
         Ok(c) => c,
         Err(e) => {
-            unsafe { libc::kill(pid, libc::SIGKILL) };
+            let _ = kill(Pid::from_raw(pid), Signal::SIGKILL);
             let _ = dump_handle.join();
             panic!("Spawning `criu lazy-pages` daemon failed: {:#?}", e);
         }
     };
-
-    // Close the parent's copy of the write end so we see EOF if the daemon
-    // exits before signalling readiness.
     drop(daemon_pipe_w);
 
-    let daemon_ready = wait_for_ready(daemon_pipe_r_fd, READY_TIMEOUT);
+    let daemon_ready = wait_for_ready(daemon_pipe_r.as_fd(), READY_TIMEOUT);
     drop(daemon_pipe_r);
 
     if !daemon_ready {
         let _ = lazy_daemon.kill();
         let _ = lazy_daemon.wait();
-        unsafe { libc::kill(pid, libc::SIGKILL) };
+        let _ = kill(Pid::from_raw(pid), Signal::SIGKILL);
         let _ = dump_handle.join();
         panic!(
             "CRIU lazy-pages daemon did not become ready within {:?}",
@@ -166,50 +163,64 @@ pub fn lazy_pages_test(criu_bin_path: &str) {
             .map_err(|e| format!("Criu::new failed: {:#?}", e))?;
         criu.set_images_dir_fd(images_dir_fd);
         criu.set_lazy_pages(true);
+        // Restore as a sibling so the task outlives the short-lived CRIU swrk for the post-restore liveness check.
+        criu.set_rst_sibling(true);
         criu.restore().map_err(|e| format!("{:#?}", e))
     })();
 
-    // Tear down background tasks: the daemon may linger if restore failed,
-    // and dump() unblocks only after the daemon is gone.
-    let _ = lazy_daemon.kill();
-    let _ = lazy_daemon.wait();
-    let dump_result = dump_handle.join();
-
     if let Err(e) = restore_result {
-        unsafe { libc::kill(pid, libc::SIGKILL) };
+        // Tear down background tasks: the daemon may linger if restore failed,
+        // and dump() unblocks only after the daemon is gone.
+        let _ = lazy_daemon.kill();
+        let _ = lazy_daemon.wait();
+        let _ = kill(Pid::from_raw(pid), Signal::SIGKILL);
+        let _ = dump_handle.join();
         panic!("criu restore failed: {:#?}", e);
     }
 
+    // Check liveness while the lazy-pages daemon is still serving page faults;
+    // once the daemon exits, the restored task will follow it.
+    if let Err(err) = kill(Pid::from_raw(pid), None) {
+        let _ = lazy_daemon.kill();
+        let _ = lazy_daemon.wait();
+        let _ = dump_handle.join();
+        panic!("restored process is not running: kill(pid={pid}, 0) failed: {err}");
+    }
+
+    let _ = lazy_daemon.wait();
+    let dump_result = dump_handle.join();
+
     if let Ok(Err(e)) = dump_result {
-        unsafe { libc::kill(pid, libc::SIGKILL) };
         panic!("criu dump (lazy-pages page-server) failed: {}", e);
     }
 
-    unsafe {
-        libc::kill(pid, libc::SIGKILL);
-        libc::waitpid(pid, std::ptr::null_mut(), 0);
-    }
+    let _ = kill(Pid::from_raw(pid), Signal::SIGKILL);
+    let _ = waitpid(Pid::from_raw(pid), None);
 
     println!("Cleaning up");
     let _ = std::fs::remove_dir_all(IMAGES_DIR);
 }
 
-fn wait_for_ready(fd: RawFd, timeout: Duration) -> bool {
+fn wait_for_ready(fd: BorrowedFd<'_>, timeout: Duration) -> bool {
+    // Set read pipe to non-blocking so the timeout loop isn't blocked forever if no data arrives
+    let flags = nix::fcntl::OFlag::from_bits_truncate(
+        nix::fcntl::fcntl(fd, nix::fcntl::FcntlArg::F_GETFL).expect("F_GETFL failed"),
+    );
+    nix::fcntl::fcntl(
+        fd,
+        nix::fcntl::FcntlArg::F_SETFL(flags | nix::fcntl::OFlag::O_NONBLOCK),
+    )
+    .expect("F_SETFL failed");
+
     let deadline = Instant::now() + timeout;
     let mut buf = [0u8; 1];
     loop {
-        let n = unsafe { libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) };
-        if n == 1 {
-            return true;
-        }
-        // EOF means CRIU closed its end without sending readiness.
-        if n == 0 {
-            return false;
-        }
-        let err = std::io::Error::last_os_error();
-        match err.raw_os_error() {
-            Some(libc::EAGAIN) | Some(libc::EINTR) => {}
-            _ => return false,
+        match nix::unistd::read(fd, &mut buf) {
+            Ok(1) => return true,
+            // EOF means CRIU closed its end without sending readiness.
+            Ok(_) => return false,
+            Err(Errno::EAGAIN) | Err(Errno::EINTR) => {}
+            Err(_) => return false,
         }
         if Instant::now() >= deadline {
             return false;

--- a/src/tests/lazy_pages.rs
+++ b/src/tests/lazy_pages.rs
@@ -1,0 +1,219 @@
+use std::os::unix::io::{AsRawFd, OwnedFd, RawFd};
+use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant};
+
+const IMAGES_DIR: &str = "test/images";
+const READY_TIMEOUT: Duration = Duration::from_secs(5);
+const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+// Create a pipe and make the read end non-blocking
+fn create_state_pipe() -> std::io::Result<(OwnedFd, OwnedFd)> {
+    let (r, w) = nix::unistd::pipe().map_err(|e| std::io::Error::from_raw_os_error(e as i32))?;
+    let fd = r.as_raw_fd();
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    if unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok((r, w))
+}
+
+// Create a checkpoint with lazy-pages enabled, then restore it.
+pub fn lazy_pages_test(criu_bin_path: &str) {
+    println!("Running lazy_pages_test");
+
+    let pid: i32 = match Command::new("test/piggie").output() {
+        Ok(p) => String::from_utf8_lossy(&p.stdout).parse().unwrap_or(0),
+        Err(e) => panic!("Starting test process failed ({:#?})", e),
+    };
+    if pid <= 0 {
+        panic!("Failed to obtain PID from test/piggie");
+    }
+
+    if let Err(e) = std::fs::create_dir(IMAGES_DIR) {
+        if e.kind() != std::io::ErrorKind::AlreadyExists {
+            unsafe { libc::kill(pid, libc::SIGKILL) };
+            panic!(
+                "Creating image directory '{}' failed with {:#?}",
+                IMAGES_DIR, e
+            );
+        }
+    }
+
+    let directory = std::fs::File::open(IMAGES_DIR).unwrap();
+    let images_dir_fd = directory.as_raw_fd();
+
+    // Wait via status_fd until dump's page-server is listening on TCP; otherwise
+    // the lazy-pages daemon's connect() races the page-server's bind()/listen().
+    let (pipe_r, pipe_w) = match create_state_pipe() {
+        Ok(p) => p,
+        Err(e) => {
+            unsafe { libc::kill(pid, libc::SIGKILL) };
+            panic!("Creating pipe failed: {:#?}", e);
+        }
+    };
+    let pipe_r_fd = pipe_r.as_raw_fd();
+    let pipe_w_fd = pipe_w.as_raw_fd();
+
+    // Dynamically choose a free ephemeral port so a leaked page-server
+    // from an earlier run does not hang this test with EADDRINUSE.
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port() as i32;
+    drop(listener);
+
+    // Run dump on a background thread: with --lazy-pages, dump() returns only
+    // after restore has fetched all pages through the daemon.
+    let criu_bin_for_dump = criu_bin_path.to_string();
+    let dump_handle = thread::spawn(move || -> Result<(), String> {
+        let mut criu = rust_criu::Criu::new_with_criu_path(criu_bin_for_dump)
+            .map_err(|e| format!("Criu::new failed: {:#?}", e))?;
+        criu.set_pid(pid);
+        criu.set_images_dir_fd(images_dir_fd);
+        criu.set_lazy_pages(true);
+        criu.set_page_server("0.0.0.0".to_string(), port);
+        criu.set_status_fd(pipe_w_fd);
+        criu.dump().map_err(|e| format!("{:#?}", e))
+    });
+
+    // Wait until CRIU reports readiness before starting the daemon.
+    let ready = wait_for_ready(pipe_r_fd, READY_TIMEOUT);
+    drop(pipe_w);
+    drop(pipe_r);
+
+    if !ready {
+        unsafe { libc::kill(pid, libc::SIGKILL) };
+        let _ = dump_handle.join();
+        panic!(
+            "CRIU lazy-pages page-server did not become ready within {:?}",
+            READY_TIMEOUT
+        );
+    }
+
+    // Launch the lazy-pages daemon and wait via --status-fd until it is listening
+    // on lazy-pages.socket
+    let (daemon_pipe_r, daemon_pipe_w) = match create_state_pipe() {
+        Ok(p) => p,
+        Err(e) => {
+            unsafe { libc::kill(pid, libc::SIGKILL) };
+            let _ = dump_handle.join();
+            panic!("Creating daemon status pipe failed: {:#?}", e);
+        }
+    };
+    let daemon_pipe_r_fd = daemon_pipe_r.as_raw_fd();
+    let daemon_pipe_w_fd = daemon_pipe_w.as_raw_fd();
+
+    // nix::unistd::pipe() sets O_CLOEXEC, so the write end must be made
+    // inheritable before spawning the daemon.
+    if unsafe { libc::fcntl(daemon_pipe_w_fd, libc::F_SETFD, 0) } < 0 {
+        unsafe { libc::kill(pid, libc::SIGKILL) };
+        let _ = dump_handle.join();
+        panic!(
+            "Clearing FD_CLOEXEC on daemon pipe failed: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+
+    println!("Spawning lazy-pages daemon");
+    let port_str = port.to_string();
+    let daemon_status_fd_str = daemon_pipe_w_fd.to_string();
+    let mut lazy_daemon = match Command::new(criu_bin_path)
+        .args([
+            "lazy-pages",
+            "--page-server",
+            "--address",
+            "127.0.0.1",
+            "--port",
+            &port_str,
+            "-D",
+            IMAGES_DIR,
+            "--status-fd",
+            &daemon_status_fd_str,
+        ])
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            unsafe { libc::kill(pid, libc::SIGKILL) };
+            let _ = dump_handle.join();
+            panic!("Spawning `criu lazy-pages` daemon failed: {:#?}", e);
+        }
+    };
+
+    // Close the parent's copy of the write end so we see EOF if the daemon
+    // exits before signalling readiness.
+    drop(daemon_pipe_w);
+
+    let daemon_ready = wait_for_ready(daemon_pipe_r_fd, READY_TIMEOUT);
+    drop(daemon_pipe_r);
+
+    if !daemon_ready {
+        let _ = lazy_daemon.kill();
+        let _ = lazy_daemon.wait();
+        unsafe { libc::kill(pid, libc::SIGKILL) };
+        let _ = dump_handle.join();
+        panic!(
+            "CRIU lazy-pages daemon did not become ready within {:?}",
+            READY_TIMEOUT
+        );
+    }
+
+    println!("Running restore");
+    let restore_result = (|| -> Result<(), String> {
+        let mut criu = rust_criu::Criu::new_with_criu_path(criu_bin_path.to_string())
+            .map_err(|e| format!("Criu::new failed: {:#?}", e))?;
+        criu.set_images_dir_fd(images_dir_fd);
+        criu.set_lazy_pages(true);
+        criu.restore().map_err(|e| format!("{:#?}", e))
+    })();
+
+    // Tear down background tasks: the daemon may linger if restore failed,
+    // and dump() unblocks only after the daemon is gone.
+    let _ = lazy_daemon.kill();
+    let _ = lazy_daemon.wait();
+    let dump_result = dump_handle.join();
+
+    if let Err(e) = restore_result {
+        unsafe { libc::kill(pid, libc::SIGKILL) };
+        panic!("criu restore failed: {:#?}", e);
+    }
+
+    if let Ok(Err(e)) = dump_result {
+        unsafe { libc::kill(pid, libc::SIGKILL) };
+        panic!("criu dump (lazy-pages page-server) failed: {}", e);
+    }
+
+    unsafe {
+        libc::kill(pid, libc::SIGKILL);
+        libc::waitpid(pid, std::ptr::null_mut(), 0);
+    }
+
+    println!("Cleaning up");
+    let _ = std::fs::remove_dir_all(IMAGES_DIR);
+}
+
+fn wait_for_ready(fd: RawFd, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    let mut buf = [0u8; 1];
+    loop {
+        let n = unsafe { libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) };
+        if n == 1 {
+            return true;
+        }
+        // EOF means CRIU closed its end without sending readiness.
+        if n == 0 {
+            return false;
+        }
+        let err = std::io::Error::last_os_error();
+        match err.raw_os_error() {
+            Some(libc::EAGAIN) | Some(libc::EINTR) => {}
+            _ => return false,
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -3,5 +3,6 @@
 pub mod action_script;
 pub mod basic;
 pub mod external_netns;
+pub mod lazy_pages;
 pub mod orphan_pts;
 pub mod version;


### PR DESCRIPTION
This option enables functionality necessary for lazy memory restore and lazy migration.
During dump it prepares memory pages to be served over the network instead of writing them to image files.