### PR TITLE
Add empty_ns option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 name = "rust-criu"
 version = "0.5.0"
 dependencies = [
+ "bitflags",
  "libc",
  "protobuf",
  "protobuf-codegen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,9 +132,9 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license-file = "LICENSE"
 libc = "0.2"
 thiserror = "1"
 protobuf = "= 3.7.2"
+bitflags = "2"
 
 [build-dependencies]
 protobuf-codegen = "= 3.7.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license-file = "LICENSE"
 libc = "0.2"
 thiserror = "2"
 protobuf = "= 3.7.2"
-nix = { version = "0.31", features = ["fs", "signal", "process"] }
+nix = { version = "0.31", features = ["fs", "sched", "signal", "process", "user"] }
 
 [build-dependencies]
 protobuf-codegen = "= 3.7.2"

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 
 use tests::action_script::action_script_test;
 use tests::basic::basic_test;
+use tests::empty_net_ns::empty_net_ns_test;
 use tests::external_netns::external_netns_test;
 use tests::lazy_pages::lazy_pages_test;
 use tests::orphan_pts::orphan_pts_master_test;
@@ -29,6 +30,7 @@ fn main() {
     basic_test(&criu_bin_path);
     action_script_test(&criu_bin_path);
     external_netns_test(&criu_bin_path);
+    empty_net_ns_test(&criu_bin_path);
     orphan_pts_master_test(&criu_bin_path);
     lazy_pages_test(&criu_bin_path);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,7 @@ pub struct Criu {
     auto_dedup: Option<bool>,
     parent_img: Option<String>,
     status_fd: Option<i32>,
+    empty_ns: Option<u32>,
 }
 
 impl Criu {
@@ -145,6 +146,7 @@ impl Criu {
             auto_dedup: None,
             parent_img: None,
             status_fd: None,
+            empty_ns: None,
         })
     }
 
@@ -535,6 +537,12 @@ impl Criu {
         self.status_fd = Some(status_fd);
     }
 
+    /// Set namespaces that should be restored as empty (bitmask of `CLONE_NEW*` flags).
+    /// See CRIU's `--empty-ns` option.
+    pub fn set_empty_ns(&mut self, empty_ns: u32) {
+        self.empty_ns = Some(empty_ns);
+    }
+
     fn fill_criu_opts(&mut self, criu_opts: &mut rpc::Criu_opts) {
         if self.pid != -1 {
             criu_opts.set_pid(self.pid);
@@ -665,6 +673,10 @@ impl Criu {
         if let Some(status_fd) = self.status_fd {
             criu_opts.set_status_fd(status_fd);
         }
+
+        if let Some(empty_ns) = self.empty_ns {
+            criu_opts.set_empty_ns(empty_ns);
+        }
     }
 
     fn clear(&mut self) {
@@ -695,6 +707,7 @@ impl Criu {
         self.auto_dedup = None;
         self.parent_img = None;
         self.status_fd = None;
+        self.empty_ns = None;
     }
 
     /// Dump (checkpoint) a process.
@@ -888,5 +901,24 @@ mod tests {
         let mut opts = rpc::Criu_opts::default();
         criu.fill_criu_opts(&mut opts);
         assert!(!opts.has_status_fd());
+    }
+
+    #[test]
+    fn set_empty_ns_fills_criu_opts() {
+        let mut criu = Criu::new().unwrap();
+        criu.set_empty_ns(libc::CLONE_NEWNET as u32);
+
+        let mut opts = rpc::Criu_opts::default();
+        criu.fill_criu_opts(&mut opts);
+        assert_eq!(opts.empty_ns(), libc::CLONE_NEWNET as u32);
+    }
+
+    #[test]
+    fn empty_ns_default_not_set() {
+        let mut criu = Criu::new().unwrap();
+
+        let mut opts = rpc::Criu_opts::default();
+        criu.fill_criu_opts(&mut opts);
+        assert!(!opts.has_empty_ns());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,18 @@ impl CgMode {
     }
 }
 
+bitflags::bitflags! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    pub struct Namespace: u32 {
+        const NET  = libc::CLONE_NEWNET  as u32;
+        const USER = libc::CLONE_NEWUSER as u32;
+        const PID  = libc::CLONE_NEWPID  as u32;
+        const UTS  = libc::CLONE_NEWUTS  as u32;
+        const IPC  = libc::CLONE_NEWIPC  as u32;
+        const MNT  = libc::CLONE_NEWNS   as u32;
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum CriuError {
     #[error("socketpair failed: {0}")]
@@ -106,7 +118,7 @@ pub struct Criu {
     auto_dedup: Option<bool>,
     parent_img: Option<String>,
     status_fd: Option<i32>,
-    empty_ns: Option<u32>,
+    empty_ns: Option<Namespace>,
 }
 
 impl Criu {
@@ -537,9 +549,7 @@ impl Criu {
         self.status_fd = Some(status_fd);
     }
 
-    /// Set namespaces that should be restored as empty (bitmask of `CLONE_NEW*` flags).
-    /// See CRIU's `--empty-ns` option.
-    pub fn set_empty_ns(&mut self, empty_ns: u32) {
+    pub fn set_empty_ns(&mut self, empty_ns: Namespace) {
         self.empty_ns = Some(empty_ns);
     }
 
@@ -675,7 +685,7 @@ impl Criu {
         }
 
         if let Some(empty_ns) = self.empty_ns {
-            criu_opts.set_empty_ns(empty_ns);
+            criu_opts.set_empty_ns(empty_ns.bits());
         }
     }
 
@@ -906,11 +916,21 @@ mod tests {
     #[test]
     fn set_empty_ns_fills_criu_opts() {
         let mut criu = Criu::new().unwrap();
-        criu.set_empty_ns(libc::CLONE_NEWNET as u32);
+        criu.set_empty_ns(Namespace::NET);
 
         let mut opts = rpc::Criu_opts::default();
         criu.fill_criu_opts(&mut opts);
-        assert_eq!(opts.empty_ns(), libc::CLONE_NEWNET as u32);
+        assert_eq!(opts.empty_ns(), Namespace::NET.bits());
+    }
+
+    #[test]
+    fn set_empty_ns_accepts_multiple_flags() {
+        let mut criu = Criu::new().unwrap();
+        criu.set_empty_ns(Namespace::NET | Namespace::IPC);
+
+        let mut opts = rpc::Criu_opts::default();
+        criu.fill_criu_opts(&mut opts);
+        assert_eq!(opts.empty_ns(), (Namespace::NET | Namespace::IPC).bits());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,7 @@ pub struct Criu {
     status_fd: Option<i32>,
     lazy_pages: Option<bool>,
     page_server: Option<(String, i32)>,
+    empty_net_ns: Option<bool>,
 }
 
 impl Criu {
@@ -149,6 +150,7 @@ impl Criu {
             status_fd: None,
             lazy_pages: None,
             page_server: None,
+            empty_net_ns: None,
         })
     }
 
@@ -540,6 +542,13 @@ impl Criu {
         self.page_server = Some((address, port));
     }
 
+    /// Restore the network namespace as empty and let an action script repopulate it.
+    /// CRIU currently only accepts the network namespace for `empty_ns`
+    /// (see criu/cr-service.c: empty_ns rejects bits other than CLONE_NEWNET).
+    pub fn set_empty_net_ns(&mut self, empty_net_ns: bool) {
+        self.empty_net_ns = Some(empty_net_ns);
+    }
+
     fn fill_criu_opts(&mut self, criu_opts: &mut rpc::Criu_opts) {
         if let Some(pid) = self.pid {
             criu_opts.set_pid(pid);
@@ -681,6 +690,10 @@ impl Criu {
             ps.set_port(port);
             criu_opts.ps = MessageField::some(ps);
         }
+
+        if let Some(true) = self.empty_net_ns {
+            criu_opts.set_empty_ns(libc::CLONE_NEWNET as u32);
+        }
     }
 
     fn clear(&mut self) {
@@ -713,6 +726,7 @@ impl Criu {
         self.status_fd = None;
         self.lazy_pages = None;
         self.page_server = None;
+        self.empty_net_ns = None;
     }
 
     /// Dump (checkpoint) a process.
@@ -943,5 +957,34 @@ mod tests {
         let mut opts = rpc::Criu_opts::default();
         criu.fill_criu_opts(&mut opts);
         assert!(opts.ps.is_none());
+    }
+
+    #[test]
+    fn set_empty_net_ns_true_fills_criu_opts() {
+        let mut criu = Criu::new().unwrap();
+        criu.set_empty_net_ns(true);
+
+        let mut opts = rpc::Criu_opts::default();
+        criu.fill_criu_opts(&mut opts);
+        assert_eq!(opts.empty_ns(), libc::CLONE_NEWNET as u32);
+    }
+
+    #[test]
+    fn set_empty_net_ns_false_does_not_fill_criu_opts() {
+        let mut criu = Criu::new().unwrap();
+        criu.set_empty_net_ns(false);
+
+        let mut opts = rpc::Criu_opts::default();
+        criu.fill_criu_opts(&mut opts);
+        assert!(!opts.has_empty_ns());
+    }
+
+    #[test]
+    fn empty_net_ns_default_not_set() {
+        let mut criu = Criu::new().unwrap();
+
+        let mut opts = rpc::Criu_opts::default();
+        criu.fill_criu_opts(&mut opts);
+        assert!(!opts.has_empty_ns());
     }
 }

--- a/src/tests/empty_net_ns.rs
+++ b/src/tests/empty_net_ns.rs
@@ -1,0 +1,184 @@
+use nix::sched::{unshare, CloneFlags};
+use nix::sys::signal::{kill, Signal};
+use nix::sys::wait::waitpid;
+use nix::unistd::{geteuid, Pid};
+use std::io::{BufRead, BufReader};
+use std::os::unix::io::AsRawFd;
+use std::os::unix::process::CommandExt;
+use std::process::Command;
+
+fn netns_contains_iface(pid: i32, iface: &str) -> std::io::Result<bool> {
+    let content = std::fs::read_to_string(format!("/proc/{}/net/dev", pid))?;
+    Ok(content.lines().any(|line| {
+        line.trim_start()
+            .strip_prefix(iface)
+            .is_some_and(|s| s.starts_with(':'))
+    }))
+}
+
+/// Verifies empty_net_ns option: network interfaces created before dump
+/// are absent after restore, confirming CRIU skips restoring network
+/// interfaces when --empty-ns net is specified.
+pub fn empty_net_ns_test(criu_bin_path: &str) {
+    if !geteuid().is_root() {
+        println!("empty_net_ns_test: skip (not root)");
+        return;
+    }
+
+    println!("Running empty_net_ns_test");
+
+    let mut child = match unsafe {
+        Command::new("test/loop")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .pre_exec(|| {
+                unshare(CloneFlags::CLONE_NEWNET)?;
+                Ok(())
+            })
+            .spawn()
+    } {
+        Ok(c) => c,
+        Err(e) => panic!("spawn loop with unshared netns failed: {:#?}", e),
+    };
+
+    let pid_raw: i32 = {
+        let mut line = String::new();
+        BufReader::new(child.stdout.take().expect("stdout should be piped"))
+            .read_line(&mut line)
+            .expect("failed to read from loop process");
+        line.trim()
+            .parse()
+            .expect("loop process did not print a valid PID")
+    };
+    let pid = Pid::from_raw(pid_raw);
+
+    let netns_path = format!("/proc/{}/ns/net", pid_raw);
+    let netns_option = format!("--net={}", &netns_path);
+
+    // Use tun device (not lo with extra IP) because lo state is always restored
+    // by CRIU regardless of empty_ns. Dummy is unsupported by CRIU.
+    let setup_steps: &[(&str, &[&str])] = &[
+        (
+            "nsenter",
+            &[&netns_option, "ip", "tuntap", "add", "tun0", "mode", "tun"],
+        ),
+        (
+            "nsenter",
+            &[
+                &netns_option,
+                "ip",
+                "addr",
+                "add",
+                "10.99.99.1/24",
+                "dev",
+                "tun0",
+            ],
+        ),
+        (
+            "nsenter",
+            &[&netns_option, "ip", "link", "set", "tun0", "up"],
+        ),
+    ];
+
+    for (cmd, args) in setup_steps {
+        let status = match Command::new(cmd).args(*args).status() {
+            Ok(s) => s,
+            Err(e) => {
+                let _ = kill(pid, Signal::SIGKILL);
+                let _ = child.wait();
+                panic!("netns setup step `{} {:?}` failed: {:#?}", cmd, args, e);
+            }
+        };
+        if !status.success() {
+            let _ = kill(pid, Signal::SIGKILL);
+            let _ = child.wait();
+            panic!(
+                "netns setup step `{} {:?}` exited with {:?}",
+                cmd, args, status
+            );
+        }
+    }
+
+    match netns_contains_iface(pid_raw, "tun0") {
+        Ok(true) => {}
+        Ok(false) => {
+            let _ = kill(pid, Signal::SIGKILL);
+            let _ = child.wait();
+            panic!(
+                "test network interface(tun0) was not visible in netns before dump (setup failed?)"
+            );
+        }
+        Err(e) => {
+            let _ = kill(pid, Signal::SIGKILL);
+            let _ = child.wait();
+            panic!(
+                "failed to read /proc/{}/net/dev before dump: {:#?}",
+                pid_raw, e
+            );
+        }
+    }
+
+    let img_dir = "test/empty_net_ns_images";
+    if let Err(e) = std::fs::create_dir(img_dir) {
+        if e.kind() != std::io::ErrorKind::AlreadyExists {
+            let _ = kill(pid, Signal::SIGKILL);
+            let _ = child.wait();
+            panic!("create_dir {} failed: {:#?}", img_dir, e);
+        }
+    }
+    let directory = std::fs::File::open(img_dir).unwrap();
+
+    let mut criu = rust_criu::Criu::new_with_criu_path(criu_bin_path.to_string()).unwrap();
+    criu.set_pid(pid_raw);
+    criu.set_images_dir_fd(directory.as_raw_fd());
+    criu.set_log_file("dump.log".to_string());
+    criu.set_log_level(4);
+    criu.set_empty_net_ns(true);
+
+    println!("Dumping PID {}", pid_raw);
+    if let Err(e) = criu.dump() {
+        let _ = kill(pid, Signal::SIGKILL);
+        let _ = child.wait();
+        panic!("empty_net_ns dump failed: {:#?}", e);
+    }
+    let _ = child.wait();
+
+    criu.set_images_dir_fd(directory.as_raw_fd());
+    criu.set_log_file("restore.log".to_string());
+    criu.set_log_level(4);
+    criu.set_empty_net_ns(true);
+
+    println!("Restoring empty_net_ns_test");
+    if let Err(e) = criu.restore() {
+        panic!("empty_net_ns restore failed: {:#?}", e);
+    }
+
+    match netns_contains_iface(pid_raw, "tun0") {
+        Ok(false) => {}
+        Ok(true) => {
+            let _ = kill(pid, Signal::SIGKILL);
+            let _ = waitpid(pid, None);
+            panic!(
+                "empty_net_ns did not produce an empty netns: test interface still present in PID {}",
+                pid_raw
+            );
+        }
+        Err(e) => {
+            let _ = kill(pid, Signal::SIGKILL);
+            let _ = waitpid(pid, None);
+            panic!(
+                "failed to read /proc/{}/net/dev after restore: {:#?}",
+                pid_raw, e
+            );
+        }
+    }
+
+    println!("Cleaning up");
+    let _ = kill(pid, Signal::SIGKILL);
+    let _ = waitpid(pid, None);
+
+    if let Err(e) = std::fs::remove_dir_all(img_dir) {
+        panic!("remove_dir_all {} failed: {:#?}", img_dir, e);
+    }
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod action_script;
 pub mod basic;
+pub mod empty_net_ns;
 pub mod external_netns;
 pub mod lazy_pages;
 pub mod orphan_pts;


### PR DESCRIPTION
This change exposes CRIU's --empty-ns so callers can have selected namespaces restored as empty and repopulated externally via action scripts.