### PR TITLE
fix: support aarch64-unknown-linux-musl target

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,3 +78,21 @@ jobs:
 
     - name: Run tests
       run: sudo -E env PATH=$PATH CRIU_BINARY=criu/criu/criu cargo test -- --test-threads=1
+
+  test-aarch64:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: checkout
+      uses: actions/checkout@v6
+
+    - name: Install cross
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cross
+
+    - name: Build for aarch64-unknown-linux-musl
+      run: cross build --target aarch64-unknown-linux-musl --verbose
+
+    - name: Run clippy for aarch64-unknown-linux-musl
+      run: cross clippy --target aarch64-unknown-linux-musl --verbose --all-targets --all-features -- -D warnings

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,7 +284,7 @@ impl Criu {
         msg.msg_iov = &mut iov;
         msg.msg_iovlen = 1;
         msg.msg_control = cmsg_buf.as_mut_ptr().cast::<libc::c_void>();
-        msg.msg_controllen = cmsg_space;
+        msg.msg_controllen = cmsg_space as _;
 
         let n = unsafe {
             let ret = libc::recvmsg(fd, &mut msg, libc::MSG_TRUNC);
@@ -803,7 +803,7 @@ mod tests {
         msg.msg_iov = &mut iov;
         msg.msg_iovlen = 1;
         msg.msg_control = cmsg_buf.as_mut_ptr().cast::<libc::c_void>();
-        msg.msg_controllen = cmsg_space;
+        msg.msg_controllen = cmsg_space as _;
         unsafe {
             let cmsg = libc::CMSG_FIRSTHDR(&msg);
             (*cmsg).cmsg_level = libc::SOL_SOCKET;


### PR DESCRIPTION
## Summary

- Fix compilation error on musl libc targets (`aarch64-unknown-linux-musl`, etc.) where `msghdr::msg_controllen` is `socklen_t` (`u32`) instead of `size_t` (`usize`) as in glibc
- Add `test-aarch64` CI job using `cross` to verify build and clippy for `aarch64-unknown-linux-musl`

## Changes

- `src/lib.rs`: Cast `cmsg_space` with `as _` so the compiler infers the correct type per target (2 occurrences)
- `.github/workflows/test.yml`: Add `test-aarch64` job with `cross build` and `cross clippy` for `aarch64-unknown-linux-musl`

## Background

When bumping rust-criu from 0.5.0 to 0.6.0 in [youki](https://github.com/youki-dev/youki), the CI failed on `aarch64-unknown-linux-musl`:

```
error[E0308]: mismatched types
   --> rust-criu-0.6.0/src/lib.rs:287:30
    |
287 |         msg.msg_controllen = cmsg_space;
    |                              ^^^^^^^^^^ expected `u32`, found `usize`
```

On glibc, `msghdr::msg_controllen` is `size_t` (`usize`), but on musl it is `socklen_t` (`u32`). Using `as _` lets the compiler infer the correct type for each target.