### PR TITLE
Bump version to 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,7 +254,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rust-criu"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "libc",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-criu"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Rust bindings for CRIU"
 repository = "https://github.com/checkpoint-restore/rust-criu"


### PR DESCRIPTION
This release includes the fix from #71 (support for \`aarch64-unknown-linux-musl\` target).

## Changes since 0.6.0

- Fix compilation error on musl libc targets (\`aarch64-unknown-linux-musl\`, etc.) where \`msghdr::msg_controllen\` is \`socklen_t\` (\`u32\`) instead of \`size_t\` (\`usize\`) as in glibc
- Add \`test-aarch64\` CI job using \`cross\` to verify build and clippy for \`aarch64-unknown-linux-musl\`

@adrianreber Could you review and merge this? Thanks!